### PR TITLE
feat: Bump component versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,17 @@ In the above diagram, you can see the components and their relations.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.33.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.37.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.12.1 |
-| <a name="provider_utils"></a> [utils](#provider\_utils) | 1.15.0 |
+| <a name="provider_utils"></a> [utils](#provider\_utils) | 1.17.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vector_agent_role"></a> [vector\_agent\_role](#module\_vector\_agent\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | v5.33.0 |
-| <a name="module_vector_aggregator_role"></a> [vector\_aggregator\_role](#module\_vector\_aggregator\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | v5.33.0 |
-| <a name="module_vector_s3_bucket"></a> [vector\_s3\_bucket](#module\_vector\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | 4.0.1 |
+| <a name="module_vector_agent_role"></a> [vector\_agent\_role](#module\_vector\_agent\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | v5.34.0 |
+| <a name="module_vector_aggregator_role"></a> [vector\_aggregator\_role](#module\_vector\_aggregator\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | v5.34.0 |
+| <a name="module_vector_s3_bucket"></a> [vector\_s3\_bucket](#module\_vector\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | 4.1.0 |
 | <a name="module_vector_sqs"></a> [vector\_sqs](#module\_vector\_sqs) | terraform-aws-modules/sqs/aws | 4.1.0 |
 
 ## Resources

--- a/examples/basic-auth-opensearch/aggregator.yaml
+++ b/examples/basic-auth-opensearch/aggregator.yaml
@@ -13,6 +13,7 @@ customConfig:
       strategy: sqs
       sqs:
         delete_message: true
+        delete_failed_message: true
         poll_secs: 15
         queue_url: "${queue_url}"
         visibility_timeout_secs: 300

--- a/examples/iam-auth-opensearch/aggregator.yaml
+++ b/examples/iam-auth-opensearch/aggregator.yaml
@@ -13,6 +13,7 @@ customConfig:
       strategy: sqs
       sqs:
         delete_message: true
+        delete_failed_message: true
         poll_secs: 15
         queue_url: "${queue_url}"
         visibility_timeout_secs: 300

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ locals {
   default_helm_chart_config = {
     chart            = "vector"
     repository       = "https://helm.vector.dev"
-    version          = "0.30.0"
+    version          = "0.31.0"
     namespace        = "vector"
     create_namespace = true
   }

--- a/s3.tf
+++ b/s3.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "s3_bucket_policy" {
 
 module "vector_s3_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.0.1"
+  version = "4.1.0"
 
   bucket        = local.bucket_name
   acl           = null

--- a/vector_agent.tf
+++ b/vector_agent.tf
@@ -116,7 +116,7 @@ resource "aws_iam_policy" "vector_agent" {
 
 module "vector_agent_role" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "v5.33.0"
+  version                       = "v5.34.0"
   create_role                   = true
   allow_self_assume_role        = false
   role_description              = "Vector Agent IRSA"

--- a/vector_aggregator.tf
+++ b/vector_aggregator.tf
@@ -110,7 +110,7 @@ resource "aws_iam_policy" "vector_aggregator" {
 
 module "vector_aggregator_role" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "v5.33.0"
+  version                       = "v5.34.0"
   create_role                   = true
   allow_self_assume_role        = false
   role_description              = "Vector Aggregator IRSA"


### PR DESCRIPTION
- Updated Vector helm chart to v0.31.0
- Updated Vector to v0.36.0
- Updated terraform providers and modules to the latest versions