### PR TITLE
feat: Bump Vector version, terraform modules versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.0
+    rev: v1.88.4
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -44,16 +44,16 @@ In the above diagram, you can see the components and their relations.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.38.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.12.1 |
-| <a name="provider_utils"></a> [utils](#provider\_utils) | 1.18.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.44.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.13.0 |
+| <a name="provider_utils"></a> [utils](#provider\_utils) | 1.19.2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vector_agent_role"></a> [vector\_agent\_role](#module\_vector\_agent\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | v5.34.0 |
-| <a name="module_vector_aggregator_role"></a> [vector\_aggregator\_role](#module\_vector\_aggregator\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | v5.34.0 |
+| <a name="module_vector_agent_role"></a> [vector\_agent\_role](#module\_vector\_agent\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | v5.38.0 |
+| <a name="module_vector_aggregator_role"></a> [vector\_aggregator\_role](#module\_vector\_aggregator\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | v5.38.0 |
 | <a name="module_vector_s3_bucket"></a> [vector\_s3\_bucket](#module\_vector\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | 4.1.0 |
 | <a name="module_vector_sqs"></a> [vector\_sqs](#module\_vector\_sqs) | terraform-aws-modules/sqs/aws | 4.1.0 |
 

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ locals {
   default_helm_chart_config = {
     chart            = "vector"
     repository       = "https://helm.vector.dev"
-    version          = "0.31.0"
+    version          = "0.32.0"
     namespace        = "vector"
     create_namespace = true
   }

--- a/vector_agent.tf
+++ b/vector_agent.tf
@@ -116,7 +116,7 @@ resource "aws_iam_policy" "vector_agent" {
 
 module "vector_agent_role" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "v5.34.0"
+  version                       = "v5.38.0"
   create_role                   = true
   allow_self_assume_role        = false
   role_description              = "Vector Agent IRSA"

--- a/vector_aggregator.tf
+++ b/vector_aggregator.tf
@@ -110,7 +110,7 @@ resource "aws_iam_policy" "vector_aggregator" {
 
 module "vector_aggregator_role" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "v5.34.0"
+  version                       = "v5.38.0"
   create_role                   = true
   allow_self_assume_role        = false
   role_description              = "Vector Aggregator IRSA"


### PR DESCRIPTION
- Bump Vector helmchart to v0.32.0, vector to v.0.37.0
- Bump all terraform modules to the latest versions
- Bump pre-commit to the latest version